### PR TITLE
Fix typo in kickstart filetype detection

### DIFF
--- a/ftdetect/kickstart.vim
+++ b/ftdetect/kickstart.vim
@@ -1,2 +1,2 @@
 " detect kickstart filetype
-au BufRead,BufNewFile *.ks setfiletype kickstart
+au BufRead,BufNewFile *.ks set filetype=kickstart


### PR DESCRIPTION
The command `setfiletype` does nothing if the filetype has already been
set in a sequence of autocommands.

If you're including this plugin, it's probably safe to assume that you
care more about Kickstart files than Kscript files, so we should
override the file type to be `kickstart`.

See http://vimdoc.sourceforge.net/htmldoc/options.html#:setfiletype for relevant documentation.
